### PR TITLE
Fix hangup in validation plugin

### DIFF
--- a/plugins/validation/index.js
+++ b/plugins/validation/index.js
@@ -16,6 +16,11 @@ function runValidation(validators, field, context, callback) {
     var result = [],
         pending = validators.length;
 
+    // Return immediately if the field has no validator defined
+    if (pending === 0) {
+        return callback(result);
+    }
+
     function validationDone(res) {
         pending--;
 
@@ -127,10 +132,6 @@ function validationPlugin(Schema) {
         }
 
         this.keys.forEach(function (key) {
-            if (self.validators[key].length === 0) {
-                return;
-            }
-
             pending++;
             runValidation(self.validators[key], model[key], model, function (res) {
                 pending--;

--- a/plugins/validation/index.js
+++ b/plugins/validation/index.js
@@ -18,7 +18,9 @@ function runValidation(validators, field, context, callback) {
 
     // Return immediately if the field has no validator defined
     if (pending === 0) {
-        return callback(result);
+        setTimeout(function () {
+            return callback(result);
+        }, 0);
     }
 
     function validationDone(res) {


### PR DESCRIPTION
Hello :smile: 

currently alamid has a small bug, which leads to a hangup with the following sample code
```js
var AlamidSchema = require("alamid-schema");
AlamidSchema.use(require("alamid-schema/plugins/validation"));

var mySchema = new AlamidSchema("MySchema", {
	var: {}
});

mySchema.validate({}, function () {
	console.log("Should call back"); // Actually it didn't!
});
```

This PR should fix the issue.

Regards,
Benjamin